### PR TITLE
⬆️🤓 Ejemplo de uso de Posts y Categorias dinamicas con "prerender false" 

### DIFF
--- a/src/pages/test-blog/[slug].astro
+++ b/src/pages/test-blog/[slug].astro
@@ -1,0 +1,46 @@
+---
+import Layout from "@src/layouts/Layout.astro";
+import { replaceIframes } from "@src/utils/index"
+import { getPostsBySlug } from "@src/services/posts";
+export const prerender = false;
+const { slug } = Astro.params;
+
+const post = await getPostsBySlug(slug);
+if (!post) {
+    return Astro.redirect("/404");
+}
+const postImage = post?.featuredImage?.node?.mediaItemUrl || "/img/branding/logo.png";
+
+
+---
+
+<Layout  image={postImage} title={post.title} description={post.excerpt}>
+  <section id="post" class="flex items-center justify-center w-full pt-36 pb-20 px-10" >
+    <article class="flex flex-col w-full max-w-[900px]" transition:name=`${post.title}-title`>
+      <div class="w-full max-w-[1300px] mx-auto overflow-hidden">
+        <img
+          class="w-full h-full object-cover"
+          src={post?.featuredImage?.node?.mediaItemUrl || "/img/branding/logo.png"}
+          alt={post.title}
+        />
+      </div>
+      <h1 class="font-bold text-[2.5rem] md:text-[4rem] my-10 text-center text-pretty" >{post.title}</h1>
+      <div class="flex gap-3 items-center my-5 px-3 group">
+          <img
+            class="w-24 h-24 group-hover:scale-110 rounded-full"
+            src={post.author?.node?.avatar?.url}
+            alt={post.author?.node?.name}
+          />
+        <p class="text-2xl font-bold">{post.author?.node?.firstName} {post.author?.node?.lastName }</p>
+      </div>
+      <div
+        class="w-full md:max-w-[800px] flex flex-col items-start gap-10 justify-center self-center text-left"
+      >
+      <Fragment server:defer set:html={replaceIframes(post.content) || ""}/>
+      </div>
+    </article>
+  </section>
+</Layout>
+<script>
+  import { fastYoutube } from "@src/utils/fast-youtube";
+</script>

--- a/src/pages/test-categories/[slug].astro
+++ b/src/pages/test-categories/[slug].astro
@@ -1,0 +1,90 @@
+---
+import Layout from "@src/layouts/Layout.astro";
+import PostCard from "@src/components/atoms/PostCard/PostCard.astro";
+import { getCategorieBySlug } from "@src/services/categories";
+export const prerender = false;
+const { slug } = Astro.params;
+
+const category = await getCategorieBySlug(slug);
+if (!category) {
+    return Astro.redirect("/404");
+}
+
+const sortedPosts = category.posts.nodes.sort(
+  (a, b) => Date.parse(b.date) - Date.parse(a.date)
+);
+---
+
+<Layout >
+    <section class="categories">
+      <div class="categories__container">
+        <h2 class="category__title">
+          Posts de la categoría: {category?.name}
+        </h2>
+        {
+          sortedPosts.length > 0 ? (
+            <ul role="list" class="link-card-grid">
+              {sortedPosts.map((post) => {
+                const featuredImage =
+                  post.featuredImage?.node?.mediaItemUrl ||
+                  "/img/branding/logo.png";
+                const altText =
+                  post.featuredImage?.node?.altText || "Imagen no disponible";
+  
+                // Logic for handling the slug of subcategory and parent
+                const primaryCategory = post.categories.nodes[0];
+                const parentCategory = primaryCategory.parent?.node;
+  
+                // Generate the correct slug based on parent presence
+                const categorySlug = parentCategory
+                  ? `/categories/${parentCategory.slug}/${primaryCategory.slug}` // Combine parent and child
+                  : `/categories/${primaryCategory.slug}`; // Only child
+  
+                return (
+                  <li>
+                    <PostCard
+                      transition:persist
+                      server:defer
+                      date={post.date}
+                      link={`/blog/${post.slug}`}
+                      title={post.title}
+                      body={post.excerpt}
+                      linkBody="Leer más"
+                      image={featuredImage}
+                      altText={altText}
+                      author={post.author.node.name}
+                      authorImage={post.author.node.avatar.url}
+                      authorFirstName={post.author.node.firstName}
+                      authorLastName={post.author.node.lastName}
+                      categories={post.categories.nodes}
+                      Assuming
+                      this
+                      is
+                      the
+                      correct
+                      reference
+                      categorySlug={categorySlug}
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p>No se encontraron posts en esta categoría.</p>
+          )
+        }
+      </div>
+    </section>
+  </Layout>
+  
+  <style lang="scss">
+    .categories {
+      padding-top: 4rem;
+      max-width: 1300px;
+      margin: 0 auto;
+      &__container {
+        align-items: center;
+      }
+    }
+  </style>
+  

--- a/src/services/categories.js
+++ b/src/services/categories.js
@@ -1,0 +1,61 @@
+import { wpquery } from "@src/data/wordpress";
+
+export const getCategorieBySlug = async (slug) => {
+    try {
+        const data = await wpquery({
+            query: `
+                query getPostsByCategory {
+                    categories(where: {slug: "${slug}"}) {
+                        edges {
+                            node {
+                                id
+                                posts {
+                                    nodes {
+                                        excerpt
+                                        author {
+                                            node {
+                                                avatar {
+                                                    url
+                                                }
+                                                firstName
+                                                lastName
+                                                name
+                                            }
+                                        }
+                                        title
+                                        slug
+                                        featuredImage {
+                                            node {
+                                                altText
+                                                sourceUrl
+                                            }
+                                        }
+                                        date
+                                        dateGmt
+                                        categories {
+                                            nodes {
+                                                name
+                                                slug
+                                            }
+                                        }
+                                    }
+                                }
+                                name
+                            }
+                        }
+                    }
+                }
+            `,
+        });
+
+        if (data.categories.edges.length === 0) {
+            throw new Error('Categoría no encontrada');
+        }
+
+        return data.categories.edges[0].node;
+    }
+    catch (error) {
+        return null;
+    }
+    
+}

--- a/src/services/posts.js
+++ b/src/services/posts.js
@@ -1,0 +1,43 @@
+import { wpquery } from "@src/data/wordpress";
+export const getPostsBySlug = async (slug) => {
+    try {
+        const data = await wpquery({
+            query: `
+                query getPostBySlug {
+                    postBy(slug: "${slug}") {
+                        title
+                        slug
+                        author {
+                            node {
+                                name
+                                avatar {
+                                    url
+                                }
+                                firstName
+                                lastName
+                            }
+                        }
+                        content
+                        date
+                        excerpt
+                        featuredImage {
+                            node {
+                                mediaItemUrl
+                                altText
+                            }
+                        }
+                    }
+                }
+            `,
+        });
+
+        if (data.postBy === null) {
+            throw new Error("Post not found");
+        }
+        return data.postBy
+    }
+    catch (error) {
+        return null
+    }
+    
+}


### PR DESCRIPTION
He creado rutas dinamicas para los posts individuales y las categorias.
 
- test-categories/[slug].astro
- test-blog/[slug].astro

En estas pagina hago uso de las rutas dinamicas y de nuevas querys para extraer los posts y categorias.
De esta forma ya no es necesario hacer uso de los getStaticPaths.

Cabe recalcar que la estructua html sigue siendo exactamente igual, ya que lo unico que se cambio es la forma de como se extrae la informacion. 