### PR TITLE
[Feature ]  🌟 Se añadio logica de registro y cierre de sesión de usuarios

### DIFF
--- a/src/pages/api/auth/register.ts
+++ b/src/pages/api/auth/register.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from "astro";
+import { registerUser } from "@src/services/auth";
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, redirect }) => {
+
+    const formData = await request.formData();
+    const user = (formData.get("username") as string) || undefined;
+    const password = (formData.get("password") as string) || undefined;
+    const email = (formData.get("email") as string) || undefined;
+    const firstName = (formData.get("firstName") as string) || undefined;
+    const lastName = (formData.get("lastName") as string) || undefined;
+
+
+    if (!user || !password || !email) return redirect("/register?error=missing-fields");
+    // añadir validaciones de email y password
+
+    const data = await registerUser({
+         username: user, 
+         password, 
+         email, 
+         firstName, 
+         lastName 
+    });
+
+    if (!data) return redirect("/register?error=invalid-credentials");
+
+    return redirect("/login?success=registered");
+}

--- a/src/pages/api/auth/signout.ts
+++ b/src/pages/api/auth/signout.ts
@@ -1,0 +1,6 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async ({ cookies, redirect }) => {
+  cookies.delete("accessToken", { path: "/" });
+  return redirect("/login");
+};

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -2,10 +2,10 @@
 import Layout from "@src/layouts/Layout.astro";
 import { isLoggedIn } from "@src/services/auth";
 export const prerender = false
-const { cookies, redirect } = Astro;
+const { cookies } = Astro;
 const data = isLoggedIn(cookies);
-if (!data) {
-  redirect("/dashboard");
+if (data) {
+  return Astro.redirect("/dashboard");
 }
 ---
 <Layout title="Login">

--- a/src/pages/register.astro
+++ b/src/pages/register.astro
@@ -1,0 +1,65 @@
+---
+import Layout from "@src/layouts/Layout.astro";
+import { isLoggedIn } from "@src/services/auth";
+export const prerender = false
+const { cookies } = Astro;
+const data = isLoggedIn(cookies);
+if (data) {
+  return Astro.redirect("/dashboard");
+}
+---
+<Layout title="Login">
+  <div class="container__login">
+    <form action="/api/auth/register" method="post" id="loginForm">
+      <div class="form__group">
+        <div>
+          <label for="firstName">First Name:</label>
+          <input type="text" name="firstName" id="firstName" required />
+        </div>
+        <div>
+          <label for="lastName">Last Name:</label>
+          <input type="text" name="firstName" id="firstName" required />
+        </div>
+      </div>
+      <label for="username">Username:</label>
+      <input type="text" id="username" name="username" required />
+      <label for="email">Email:</label>
+      <input type="email" name="email" id="email" required />
+      <label for="password">Password</label>
+      <input type="password" name="password" id="password" required />
+      <button type="submit">
+        Register
+      </button>
+    </form>
+  </div>
+</Layout>
+
+<style>
+  .container__login {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    font-size: 1.5rem;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background: #1f2335;
+    padding: 2rem;
+    border-radius: 10px;
+  }
+
+  button {
+    padding: 0.5rem;
+    background: #673AB7;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  textarea:focus, input:focus {
+    color: #201b2b79;
+  }
+</style>

--- a/src/types/registerUser.type.ts
+++ b/src/types/registerUser.type.ts
@@ -1,0 +1,12 @@
+export interface RegisterUser {
+    email: string;
+    password: string;
+    firstName: string;
+    lastName: string;
+    username: string;
+}
+
+export type RegisterUserResponse = {
+    username: string;
+    email: string;
+}


### PR DESCRIPTION
- Se creo el servicio de RegisterUser y la query de WPGraphQL para crear los usuarios.
- Se creo la ruta `api/auth/register` para capturar los datos del fomulario de registro y se creo la logica de la misma.
- Se crearon interfaces para los tipos de RegisterUser
- Se creo el register.astro con el formulario.

**ADICIONAL**
- Se añadio la ruta `api/auth/signout` para cerrar session. (simplemete ingresar a esta ruta para cerrar session)
- Se corrigio un pequeño error en la redireccion de login.astro.

**EXEMPLOS:**

Registro:
  https://github.com/user-attachments/assets/c4ce9508-3850-46fb-8352-b51810d57fcf

Cierre de session:

https://github.com/user-attachments/assets/f0206a9f-c34c-40f0-994e-02126e9dc819


