### PR TITLE
[Fix and feature] Ya se puede responder

### DIFF
--- a/src/components/molecules/CommentForm/CommentForm.astro
+++ b/src/components/molecules/CommentForm/CommentForm.astro
@@ -62,7 +62,10 @@ const { postId = null, name, email="", website="", content=""  } = Astro.props;
 
   comments.addEventListener("click", (event) => {
     if (event.target.classList.contains("reply")) {
-      const commentId = event.target.dataset.commentId;
+      console.log(event.target)
+      let commentId = event.target.getAttribute("data-commentId");
+      commentId = commentId ? atob(commentId).split(':')[1] : null;
+      console.log(commentId)
       const form = document.getElementById("comment-form");
       form.querySelector("input[name='parentId']").value = commentId;
     }

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -15,6 +15,7 @@ const posts = await getPostsByUserID(user.id);
   <section id="dashboard">
     <div class="container__dashboard">
         <h1>Bienvenid@ { user.name } </h1>
+        <span> { user.email } </span>
         <h2> Mis Posts </h2>
         {
             posts.posts.edges.map((post) => (

--- a/src/services/auth/getUserByName.ts
+++ b/src/services/auth/getUserByName.ts
@@ -2,14 +2,13 @@ import { wpquery } from "@src/data/wordpress";
 
 const { SECRET_USER, SECRET_PASSWORD   } = import.meta.env
 
-export async function getUserById( id: string ) {
+export async function getUserByName( id: string ) {
     const query = `
-       query MyQuery7 {
-            user(id: "${id}") {
-                email
-                userId
-                username
-                slug
+        query getUserByEmail {
+            users(where: {login: "${id}"}) {
+                nodes {
+                    email
+                }
             }
         }
   `;

--- a/src/services/comments.js
+++ b/src/services/comments.js
@@ -5,7 +5,7 @@ export const getCommentsByPostSlug = async (slug) => {
             query: `
                 query getComments {
                     postBy(slug: "${slug}") {
-                        comments {
+                        comments(last: 100) {
                             nodes {
                                 content
                                 author {


### PR DESCRIPTION
- Al dar click en responder, se actualiza el parentID en el formulario.
- Ya se añade automaticamente el PostID al formulario.
- Se dio soporte a parentId y postID en la api ruta.
- Se creo una query para obtener el email al logearse, ya que WpAPI no lo soprota por defecto. Esto es necesario para poderlo incluir a la hora de enviar un comentario logeado, wordpress haga match con un usuario existente y coloque la foto de perfil correcta.
- Se implemento la query para obtener el email en isValidUser.ts

Extra:
- Se corrigio la url de isValidUser que daba error por el reciente cambio de la env.
- Se soluciono el limite de comentarios.